### PR TITLE
Fix control names

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-opcua (1.0.5) stable; urgency=medium
+
+  * Fix control names
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 02 May 2023 18:25:00 +0400
+
 wb-mqtt-opcua (1.0.4) stable; urgency=medium
 
   * mosquitto.target dependency is replaced by mosquitto.service

--- a/src/OPCUAServer.cpp
+++ b/src/OPCUAServer.cpp
@@ -286,7 +286,7 @@ namespace
 
         UA_StatusCode writeVariable(const UA_NodeId* snodeId, const UA_DataValue* dataValue)
         {
-            std::string nodeIdName((const char*)snodeId->identifier.string.data);
+            std::string nodeIdName((const char*)snodeId->identifier.string.data, snodeId->identifier.string.length);
             auto tx = Driver->BeginTx();
             auto ctrl = GetControl(tx, nodeIdName);
             if (!ctrl || ctrl->IsReadonly()) {
@@ -324,7 +324,7 @@ namespace
 
         UA_StatusCode readVariable(const UA_NodeId* snodeId, UA_DataValue* dataValue)
         {
-            std::string nodeIdName((const char*)snodeId->identifier.string.data);
+            std::string nodeIdName((const char*)snodeId->identifier.string.data, snodeId->identifier.string.length);
             auto tx = Driver->BeginTx();
             auto ctrl = GetControl(tx, nodeIdName);
             if (!ctrl) {


### PR DESCRIPTION
`data` is not null-terminated, https://github.com/open62541/open62541/blob/beeafc02e9f98c52f0dee2364620f5c3527da5db/include/open62541/types.h#L148-L155:
```cpp
/**
 * String
 * ^^^^^^
 * A sequence of Unicode characters. Strings are just an array of UA_Byte. */
typedef struct {
    size_t length; /* The length of the string */
    UA_Byte *data; /* The content (not null-terminated) */
} UA_String;
```