### PR TITLE
jenkinsfile: disable clang-tidy completely

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,4 @@
 buildDebSbuild defaultTargets: 'bullseye-armhf bullseye-arm64',
                defaultRunLintian: true,
-               defaultStyleCheckDirs: 'src test'
+               defaultStyleCheckDirs: '',  // FIXME: clang-tidy breaks here. See SOFT-4261
+               defaultAngryClangTidy: false


### PR DESCRIPTION
временно отключил clang-tidy при сборке, т.к. падают билды. замечено в main и релизной ветке. тикет на исправление SOFT-4261