### PR TITLE
Add coverage report generation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,6 @@
 buildDebSbuild defaultTargets: 'bullseye-armhf bullseye-arm64',
                defaultRunLintian: true,
                defaultStyleCheckDirs: 'src test',
-               defaultClangTidyPreHook: 'make open62541_build'
+               defaultClangTidyPreHook: 'make open62541_build',
+               defaultRunCoverage: false,
+               defaultCoverageMin: '29'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,4 +3,4 @@ buildDebSbuild defaultTargets: 'bullseye-armhf bullseye-arm64',
                defaultStyleCheckDirs: 'src test',
                defaultClangTidyPreHook: 'make open62541_build',
                defaultRunCoverage: false,
-               defaultCoverageMin: '29'
+               defaultCoverageMin: '30'

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ TEST_TARGET = test-app
 TEST_LDFLAGS = -lgtest -lwbmqtt_test_utils
 
 COV_REPORT ?= $(BUILD_DIR)/cov.html
-GCOVR_FLAGS := --html $(COV_REPORT) -e $(LIB62541_BUILD_DIR)
+GCOVR_FLAGS := -s --html $(COV_REPORT) -e $(LIB62541_BUILD_DIR)
 ifneq ($(COV_FAIL_UNDER),)
 	GCOVR_FLAGS += --fail-under-line $(COV_FAIL_UNDER)
 endif

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+PREFIX = /usr
+
 ifneq ($(DEB_HOST_MULTIARCH),)
 	CROSS_COMPILE ?= $(DEB_HOST_MULTIARCH)-
 endif
@@ -102,9 +104,9 @@ clean:
 	rm -rf $(BUILD_DIR)
 
 install:
-	install -Dm0644 wb-mqtt-opcua.schema.json -t $(DESTDIR)/usr/share/wb-mqtt-confed/schemas
-	install -Dm0644 wb-mqtt-opcua.sample.conf -t $(DESTDIR)/usr/share/wb-mqtt-opcua
-	install -Dm0755 $(BUILD_DIR)/$(TARGET) -t $(DESTDIR)/usr/bin
+	install -Dm0644 wb-mqtt-opcua.schema.json -t $(DESTDIR)$(PREFIX)/share/wb-mqtt-confed/schemas
+	install -Dm0644 wb-mqtt-opcua.sample.conf -t $(DESTDIR)$(PREFIX)/share/wb-mqtt-opcua
+	install -Dm0755 $(BUILD_DIR)/$(TARGET) -t $(DESTDIR)$(PREFIX)/bin
 	install -Dm0644 wb-mqtt-opcua.wbconfigs $(DESTDIR)/etc/wb-configs.d/18wb-mqtt-opcua
 
 .PHONY: all test clean open62541_build

--- a/Makefile
+++ b/Makefile
@@ -101,12 +101,13 @@ else
 endif
 
 clean:
-	rm -rf $(BUILD_DIR)
+	-rm -rf $(BUILD_DIR)
+	-rm -rf $(TEST_DIR)/$(TEST_TARGET)
 
 install:
+	install -Dm0755 $(BUILD_DIR)/$(TARGET) -t $(DESTDIR)$(PREFIX)/bin
 	install -Dm0644 wb-mqtt-opcua.schema.json -t $(DESTDIR)$(PREFIX)/share/wb-mqtt-confed/schemas
 	install -Dm0644 wb-mqtt-opcua.sample.conf -t $(DESTDIR)$(PREFIX)/share/wb-mqtt-opcua
-	install -Dm0755 $(BUILD_DIR)/$(TARGET) -t $(DESTDIR)$(PREFIX)/bin
 	install -Dm0644 wb-mqtt-opcua.wbconfigs $(DESTDIR)/etc/wb-configs.d/18wb-mqtt-opcua
 
 .PHONY: all test clean open62541_build

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,8 @@ TEST_OBJS := $(TEST_SRCS:%=$(BUILD_DIR)/%.o)
 TEST_TARGET = test-app
 TEST_LDFLAGS = -lgtest -lwbmqtt_test_utils
 
-COV_REPORT ?= $(BUILD_DIR)/cov.html
-GCOVR_FLAGS := -s --html $(COV_REPORT) -e $(LIB62541_BUILD_DIR)
+COV_REPORT ?= $(BUILD_DIR)/cov
+GCOVR_FLAGS := -e $(LIB62541_BUILD_DIR) -s --html $(COV_REPORT).html -x $(COV_REPORT).xml
 ifneq ($(COV_FAIL_UNDER),)
 	GCOVR_FLAGS += --fail-under-line $(COV_FAIL_UNDER)
 endif

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-opcua (1.1.10) stable; urgency=medium
+
+  * Add coverage report generation, no functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 26 Sep 2024 20:10:00 +0400
+
 wb-mqtt-opcua (1.1.9) stable; urgency=medium
 
   * Add dependency from libwbmqtt1-5. No functional changes

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,12 @@ Maintainer: Wiren Board team <info@wirenboard.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 10), pkg-config, libwbmqtt1-5-dev, libwbmqtt1-5-test-utils, libgtest-dev
+Build-Depends: debhelper (>= 10),
+               gcovr:all,
+               libgtest-dev,
+               libwbmqtt1-5-dev,
+               libwbmqtt1-5-test-utils,
+               pkg-config
 Homepage: https://github.com/wirenboard/wb-mqtt-opcua
 
 Package: wb-mqtt-opcua

--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,18 @@
 #!/usr/bin/make -f
 
+COV_FAIL_UNDER := $(patsubst cov-fail-under=%,%,$(filter cov-fail-under=%,$(DEB_BUILD_OPTIONS)))
+COV_REPORT     := $(patsubst cov-report=%,%,$(filter cov-report=%,$(DEB_BUILD_OPTIONS)))
+
+ifneq ($(COV_FAIL_UNDER),)
+	MAKEFLAGS += COV_FAIL_UNDER=$(COV_FAIL_UNDER)
+endif
+ifneq ($(COV_REPORT),)
+	MAKEFLAGS += COV_REPORT=$(COV_REPORT)
+endif
+ifneq (,$(findstring debug, $(DEB_BUILD_OPTIONS)))
+	MAKEFLAGS += DEBUG=1
+endif
+
 %:
 	dh $@ --parallel
 


### PR DESCRIPTION
How to use (with devcontainer):
```sh
make test DEBUG=1
open build/debug/cov.html
```
Using wbdev:
```sh
DEB_BUILD_OPTIONS="debug check cov-fail-under=29 cov-report=cov.html" ./wbdev cdeb
```

<img width="1680" alt="Näyttökuva 2024-10-1 kello 11 17 31" src="https://github.com/user-attachments/assets/98510134-5ddb-45f6-98df-f45e086ee110">
